### PR TITLE
Include javax.xml.bind to pom.xml

### DIFF
--- a/spring/lab2/pom.xml
+++ b/spring/lab2/pom.xml
@@ -26,6 +26,12 @@
 
 	<dependencies>
 
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+				<artifactId>jaxb-api</artifactId>
+			<version>2.3.0</version>
+		</dependency>
+
 		<!-- For Web and REST support -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
It occured when I took the course of Cloud-Native Development Foundations.
Section is below.
```
Lab 3.2 : Spring Data and JPA
    - 4. Create Unit Test
        - 5 Test that JPA bootstraps successfully:
```
I run the code and got errors.
```
$ mvn clean verify
...
2019-06-11 15:45:37.121  INFO 8776 --- [           main] org.hibernate.Version                    : HHH000412: Hibernate Core {5.0.12.Final}
2019-06-11 15:45:37.122  INFO 8776 --- [           main] org.hibernate.cfg.Environment            : HHH000206: hibernate.properties not found
2019-06-11 15:45:37.123  INFO 8776 --- [           main] org.hibernate.cfg.Environment            : HHH000021: Bytecode provider name : javassist
2019-06-11 15:45:37.134  WARN 8776 --- [           main] o.s.w.c.s.GenericWebApplicationContext   : Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityManagerFactory' defined in class path resource [org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaAutoConfiguration.class]: Invocation of init method failed; nested exception is java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException
2019-06-11 15:45:37.137  INFO 8776 --- [           main] utoConfigurationReportLoggingInitializer : 

Error starting ApplicationContext. To display the auto-configuration report re-run your application with 'debug' enabled.
2019-06-11 15:45:37.148 ERROR 8776 --- [           main] o.s.boot.SpringApplication               : Application startup failed
…
Results :

Tests in error: 
  ProductCatalogApplicationTests.contextLoads » IllegalState Failed to load Appl...
  ProductCatalogApplicationTests.testDefaultProductList » IllegalState Failed to...
  ProductCatalogJPATests.testFindAll » IllegalState Failed to load ApplicationCo...

Tests run: 3, Failures: 0, Errors: 3, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.405 s
[INFO] Finished at: 2019-06-11T15:45:38+09:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.18.1:test (default-test) on project product-catalog-lab2: There are test failures.
[ERROR] 
[ERROR] Please refer to /Users/hsasagaw/Desktop/training/appmod_foundations_training/spring/lab2/target/surefire-reports for the individual test results.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```

I think it needed to include ```javax.xml.bind``` in pom.xml.  
I fixed it and run, tests exited with success.
```
$ mvn clean verify
...
2019-06-11 15:47:17.480  INFO 8828 --- [           main] org.hibernate.Version                    : HHH000412: Hibernate Core {5.0.12.Final}
2019-06-11 15:47:17.481  INFO 8828 --- [           main] org.hibernate.cfg.Environment            : HHH000206: hibernate.properties not found
2019-06-11 15:47:17.482  INFO 8828 --- [           main] org.hibernate.cfg.Environment            : HHH000021: Bytecode provider name : javassist
2019-06-11 15:47:17.521  INFO 8828 --- [           main] o.hibernate.annotations.common.Version   : HCANN000001: Hibernate Commons Annotations {5.0.1.Final}
2019-06-11 15:47:17.606  INFO 8828 --- [           main] org.hibernate.dialect.Dialect            : HHH000400: Using dialect: org.hibernate.dialect.H2Dialect
2019-06-11 15:47:17.785  INFO 8828 --- [           main] org.hibernate.tool.hbm2ddl.SchemaExport  : HHH000227: Running hbm2ddl schema export
2019-06-11 15:47:17.787  INFO 8828 --- [           main] org.hibernate.tool.hbm2ddl.SchemaExport  : HHH000230: Schema export complete
2019-06-11 15:47:17.812  INFO 8828 --- [           main] j.LocalContainerEntityManagerFactoryBean : Initialized JPA EntityManagerFactory for persistence unit 'default'
2019-06-11 15:47:17.982  INFO 8828 --- [           main] c.r.c.p.ProductCatalogJPATests           : Started ProductCatalogJPATests in 1.667 seconds (JVM running for 2.294)
2019-06-11 15:47:18.062  INFO 8828 --- [           main] o.s.t.c.transaction.TransactionContext   : Began transaction 
…
2019-06-11 15:47:19.379  INFO 8828 --- [       Thread-1] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2019-06-11 15:47:19.380  INFO 8828 --- [       Thread-1] org.hibernate.tool.hbm2ddl.SchemaExport  : HHH000227: Running hbm2ddl schema export
2019-06-11 15:47:19.380  INFO 8828 --- [       Thread-4] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2019-06-11 15:47:19.380  INFO 8828 --- [       Thread-4] org.hibernate.tool.hbm2ddl.SchemaExport  : HHH000227: Running hbm2ddl schema export
2019-06-11 15:47:19.382  INFO 8828 --- [       Thread-4] org.hibernate.tool.hbm2ddl.SchemaExport  : HHH000230: Schema export complete
2019-06-11 15:47:19.382  INFO 8828 --- [       Thread-1] org.hibernate.tool.hbm2ddl.SchemaExport  : HHH000230: Schema export complete

Results :

Tests run: 3, Failures: 0, Errors: 0, Skipped: 0

[INFO] 
[INFO] --- maven-jar-plugin:2.6:jar (default-jar) @ product-catalog-lab2 ---
[INFO] Building jar: /Users/hsasagaw/Desktop/training/appmod_foundations_training/spring/lab2/target/product-catalog-lab2-0.0.1-SNAPSHOT.jar
[INFO] 
[INFO] --- spring-boot-maven-plugin:1.5.16.RELEASE:repackage (default) @ product-catalog-lab2 ---
Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-loader-tools/1.5.16.RELEASE/spring-boot-loader-tools-1.5.16.RELEASE.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-loader-tools/1.5.16.RELEASE/spring-boot-loader-tools-1.5.16.RELEASE.pom (3.8 kB at 3.9 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-loader-tools/1.5.16.RELEASE/spring-boot-loader-tools-1.5.16.RELEASE.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-loader-tools/1.5.16.RELEASE/spring-boot-loader-tools-1.5.16.RELEASE.jar (153 kB at 266 kB/s)
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  8.135 s
[INFO] Finished at: 2019-06-11T15:47:21+09:00
[INFO] ------------------------------------------------------------------------
```